### PR TITLE
Adding methods for avoiding waiting for images to be available in getimage(), which blocks 

### DIFF
--- a/src/Camera.jl
+++ b/src/Camera.jl
@@ -14,7 +14,7 @@ export serial, model, vendor, isrunning, start!, stop!, getimage, getimage!, sav
        pixelformat, pixelformat!,
        acqusitionmode, acquisitionmode!,
        sensordims, imagedims, imagedims!, imagedims_limits, offsetdims, offsetdims!, offsetdims_limits,
-       buffercount, buffercount!, buffermode, buffermode!, bufferunderrun, bufferfailed
+       buffercount, buffercount!, buffermode, buffermode!, buffertotalcount, bufferunderrun, bufferfailed
 
 """
  Spinnaker SDK Camera object

--- a/src/Camera.jl
+++ b/src/Camera.jl
@@ -14,7 +14,8 @@ export serial, model, vendor, isrunning, start!, stop!, getimage, getimage!, sav
        pixelformat, pixelformat!,
        acqusitionmode, acquisitionmode!,
        sensordims, imagedims, imagedims!, imagedims_limits, offsetdims, offsetdims!, offsetdims_limits,
-       buffercount, buffercount!, buffermode, buffermode!, buffertotalcount, bufferunderrun, bufferfailed
+       buffercount, buffercount!, buffermode, buffermode!, totalbuffercount, bufferunderrun, bufferfailed,
+       blocktransfersize, blocktransfersize!
 
 """
  Spinnaker SDK Camera object

--- a/src/Camera.jl
+++ b/src/Camera.jl
@@ -15,7 +15,8 @@ export serial, model, vendor, isrunning, start!, stop!, getimage, getimage!, sav
        acqusitionmode, acquisitionmode!,
        sensordims, imagedims, imagedims!, imagedims_limits, offsetdims, offsetdims!, offsetdims_limits,
        buffercount, buffercount!, buffermode, buffermode!, totalbuffercount, bufferunderrun, bufferfailed,
-       blocktransfersize, blocktransfersize!
+       blocktransfersize, blocktransfersize!,
+       supportedeventsources, eventsource, eventsource!, eventnotification, eventnotification!
 
 """
  Spinnaker SDK Camera object
@@ -97,6 +98,7 @@ include(joinpath("camera", "acquisition.jl"))
 include(joinpath("camera", "analog.jl"))
 include(joinpath("camera", "format.jl"))
 include(joinpath("camera", "stream.jl"))
+include(joinpath("camera", "event.jl"))
 
 #
 # Device metadata

--- a/src/NodeMap.jl
+++ b/src/NodeMap.jl
@@ -5,6 +5,12 @@
 
 abstract type AbstractNodeMap end
 
+function _nodemap(cam, nm::AbstractNodeMap)
+  hNodeMap = Ref(spinNodeMapHandle(C_NULL))
+  _nodemap!(cam, hNodeMap, nm) 
+  return hNodeMap
+end
+
 struct CameraNodeMap <: AbstractNodeMap end
 
 function _nodemap!(cam, hNodeMap, nm::CameraNodeMap) 

--- a/src/Nodes.jl
+++ b/src/Nodes.jl
@@ -38,12 +38,6 @@ function _getnode(cam, name::String, nodemap)
   return hNode
 end
 
-function _getnodemap(cam, nodemap)
-  hNodeMap = Ref(spinNodeMapHandle(C_NULL))
-  _nodemap!(cam, hNodeMap, nodemap) 
-  return hNodeMap
-end
-
 abstract type AbstractSpinNode end
 
 function invalidate!(node::AbstractSpinNode)
@@ -51,7 +45,7 @@ function invalidate!(node::AbstractSpinNode)
 end
 
 function poll!(cam, nodemap)
-  spinNodeMapPoll(_getnodemap(cam,nodemap)[],0)
+  spinNodeMapPoll(_nodemap(cam,nodemap)[],0)
 end
 
 function pollingtime(node::AbstractSpinNode)

--- a/src/Nodes.jl
+++ b/src/Nodes.jl
@@ -38,7 +38,27 @@ function _getnode(cam, name::String, nodemap)
   return hNode
 end
 
+function _getnodemap(cam, nodemap)
+  hNodeMap = Ref(spinNodeMapHandle(C_NULL))
+  _nodemap!(cam, hNodeMap, nodemap) 
+  return hNodeMap
+end
+
 abstract type AbstractSpinNode end
+
+function invalidate!(node::AbstractSpinNode)
+  spinNodeInvalidateNode(node.hNode[])
+end
+
+function poll!(cam, nodemap)
+  spinNodeMapPoll(_getnodemap(cam,nodemap)[],0)
+end
+
+function pollingtime(node::AbstractSpinNode)
+  hval = Ref(Int64(0))
+  spinNodeGetPollingTime(node.hNode[],hval)
+  return hval[]
+end
 
 
 #

--- a/src/Nodes.jl
+++ b/src/Nodes.jl
@@ -40,12 +40,8 @@ end
 
 abstract type AbstractSpinNode end
 
-function invalidate!(node::AbstractSpinNode)
-  spinNodeInvalidateNode(node.hNode[])
-end
-
 function poll!(cam, nodemap)
-  spinNodeMapPoll(_nodemap(cam,nodemap)[],0)
+  spinNodeMapPoll(nodemap.hNodeMap[],0)
 end
 
 function pollingtime(node::AbstractSpinNode)

--- a/src/camera/event.jl
+++ b/src/camera/event.jl
@@ -106,6 +106,7 @@ end
 
 #typedef void(*spinDeviceEventFunction)(const spinDeviceEventData hEventData, const char* pEventName, void* pUserData);
 function printevent(hEventData::spinDeviceEventData, pEventName::Cstring, pUserData::Ptr{Cvoid})::Cvoid
+  println("event happened")
 end
 
 function test(cam::Camera)

--- a/src/camera/event.jl
+++ b/src/camera/event.jl
@@ -1,0 +1,94 @@
+
+# Spinnaker.jl: wrapper for FLIR/Point Grey Spinnaker SDK
+# Copyright (C) 2019 Samuel Powell
+
+# event.jl: functions to control event notification
+
+"""
+    supportedeventsources(cam::Camera) -> String[]
+
+    Return all supported event sources.
+"""
+
+function supportedeventsources(cam::Camera)  
+  possiblesources = [
+    "AcquisitionTrigger","AcquisitionStart","AcquisitionEnd","AcquisitionTransferStart","AcquisitionTransferEnd","AcquisitionError", 
+    "FrameTrigger","FrameStart","FrameEnd","FrameBurstStart","FrameBurstEnd","FrameTransferStart","FrameTransferEnd", 
+    "ExposureStart","ExposureEnd", "Stream0TransferStart","Stream0TransferEnd","Stream0TransferPause","Stream0TransferResume",
+    "Stream0TransferBlockStart","Stream0TransferBlockEnd","Stream0TransferBlockTrigger",
+    "Stream0TransferBurstStart","Stream0TransferBurstEnd",
+    "Stream0TransferOverflow",
+    "SequencerSetChange",
+    "Counter0Start","Counter0End",
+    "Counter1Start","Counter1End",
+    "Timer0Start","Timer0End",
+    "Timer1Start","Timer1End",
+    "Encoder0Stopped","Encoder0Restarted",
+    "Encoder1Stopped","Encoder1Restarted",
+    "Line0RisingEdge","Line0FallingEdge",
+    "Line1RisingEdge","Line1FallingEdge",
+    "Line0AnyEdge","LinkTrigger0",
+    "Line1AnyEdge","LinkTrigger1",
+    "ActionLate",
+    "LinkSpeedChange",
+    "Error",
+    "Test",
+    "PrimaryApplicationSwitch"
+  ]
+  startingsource = eventsource(cam)
+  supported = String[]
+  for source in possiblesources
+    try
+      eventsource!(cam,source)
+      push!(supported,source)
+    catch e
+      if !(occursin("SPINNAKER_ERR_INVALID_HANDLE(-1006)",sprint(showerror, e)) || occursin("entry is not readable",sprint(showerror, e)))
+        rethrow()
+      end
+    end
+  end
+  eventsource!(cam,startingsource)
+  return supported
+end
+
+"""
+	eventsource!(cam::Camera, source::String) -> String
+
+	Set the event source, supported options can be returned using supportedeventsources(cam)
+"""
+function eventsource!(cam::Camera, source::String)
+  set!(SpinEnumNode(cam, "EventSelector"), source)
+  eventsource(cam)
+end
+
+"""
+	eventsource(::Camera) -> String
+
+	Get the event source.
+"""
+function eventsource(cam::Camera)
+	get(SpinEnumNode(cam, "EventSelector"))
+end
+
+"""
+	eventnotification(::Camera) -> String
+
+	Return whether event notification is enabled
+"""
+function eventnotification(cam::Camera)
+	get(SpinEnumNode(cam, "EventNotification")) == "On"
+end
+
+"""
+	eventnotification!(::Camera, state::Bool) -> String
+
+	Return whether event notification is enabled
+"""
+function eventnotification!(cam::Camera, state::Bool)
+    str = state ? "On" : "Off"
+	set!(SpinEnumNode(cam, "EventNotification"), str)
+    eventnotification(cam)
+end
+
+
+

--- a/src/camera/event.jl
+++ b/src/camera/event.jl
@@ -91,4 +91,51 @@ function eventnotification!(cam::Camera, state::Bool)
 end
 
 
+### EXPERIMENTAL BELOW HERE
+
+
+#function registereventcallback(cam::Camera,f::Function)
+#  c_f = @cfunction($f, Cvoid, (Cstring,C_NULL))
+#  event = spinDeviceEvent(C_NULL)
+#  spinDeviceEventCreate(Ref(event),c_f,C_NULL)
+#  spinCameraRegisterDeviceEventEx(cam,event,"EventExposureEnd")
+#  return event
+#end
+
+
+
+#typedef void(*spinDeviceEventFunction)(const spinDeviceEventData hEventData, const char* pEventName, void* pUserData);
+function printevent(hEventData::spinDeviceEventData, pEventName::Cstring, pUserData::Ptr{Cvoid})::Cvoid
+end
+
+function test(cam::Camera)
+  c_f = @cfunction(printevent, Cvoid, (Ptr{Cvoid}, Cstring, Ref{Cvoid}))
+  event = spinDeviceEvent(C_NULL)
+  
+  #spinDeviceEventCreate(spinDeviceEvent* phDeviceEvent, spinDeviceEventFunction pFunction, void* pUserData);
+  spinDeviceEventCreate(Ref{event}, c_f, Ptr{Cvoid})
+  
+  #spinCameraRegisterDeviceEvent(spinCamera hCamera, spinDeviceEvent hDeviceEvent);
+  spinCameraRegisterDeviceEventEx(cam, event, "EventExposureEnd")
+  return event
+end
+  
+  
+"""
+Example c code
+NOTE: This code is out of date. Various names and argument requirements have changed
+
+// Create and register ExposureEvent
+spinEvent eventExposureEnd = NULL;
+error = spinEventCreate(&eventExposureEnd, onSpecificDeviceEvent, NULL);
+error = spinCameraRegisterEvent(hCam, eventExposureEnd, "EventExposureEnd");
+// Create a function to occur upon specific event occurrences;
+//ensure exact same function signature is used
+
+void onSpecificDeviceEvent(const char* pEventName, void* pUserData)
+{
+    printf("\t// Specific device event %s...\n", pEventName, (char*)pUserData);
+}
+"""
+
 

--- a/src/camera/stream.jl
+++ b/src/camera/stream.jl
@@ -36,9 +36,13 @@ end
 	Counts the number of image buffers that arrived since stream started.
 """
 function totalbuffercount(cam::Camera)
-	invalidate!(SpinIntegerNode(cam, "StreamTotalBufferCount", CameraTLStreamNodeMap()))
-    #poll!(cam, CameraTLStreamNodeMap())
-    return get(SpinIntegerNode(cam, "StreamTotalBufferCount", CameraTLStreamNodeMap()))
+    node = SpinIntegerNode(cam, "StreamTotalBufferCount", CameraTLStreamNodeMap())
+    spinNodeInvalidateNode(node.hNode[])
+    
+    nodemap = CameraTLStreamNodeMap()
+    spinNodeMapPoll(nodemap.hNodeMap[],0)
+    
+    return get(node)
 end
 
 """

--- a/src/camera/stream.jl
+++ b/src/camera/stream.jl
@@ -40,6 +40,25 @@ function totalbuffercount(cam::Camera)
 end
 
 """
+	blocktransfersize(::Camera) -> Int
+
+	Return the image breakup size that is used.
+"""
+function blocktransfersize(cam::Camera)
+	get(SpinIntegerNode(cam, "StreamBlockTransferSize", CameraTLStreamNodeMap()))
+end
+
+"""
+	blocktransfersize!(::Camera) -> Int
+
+	Controls the image breakup size that should be used on the stream.
+"""
+function blocktransfersize!(cam::Camera, size::Integer)
+	set!(SpinIntegerNode(cam, "StreamBlockTransferSize", CameraTLStreamNodeMap()),size)
+    blocktransfersize(cam)
+end
+
+"""
 	buffercount(::Camera) -> (Int, String)
 
 	Return the buffer count mode and specified number of buffers.

--- a/src/camera/stream.jl
+++ b/src/camera/stream.jl
@@ -31,11 +31,11 @@ function buffermode!(cam::Camera, mode::String)
 end
 
 """
-	buffertotalcount(::Camera) -> Int
+	totalbuffercount(::Camera) -> Int
 
 	Counts the number of image buffers that arrived since stream started.
 """
-function buffertotalcount(cam::Camera)
+function totalbuffercount(cam::Camera)
 	Int(get(SpinIntegerNode(cam, "StreamTotalBufferCount", CameraTLStreamNodeMap())))
 end
 

--- a/src/camera/stream.jl
+++ b/src/camera/stream.jl
@@ -30,6 +30,14 @@ function buffermode!(cam::Camera, mode::String)
 	set!(SpinEnumNode(cam, "StreamBufferHandlingMode", CameraTLStreamNodeMap()), mode)
 end
 
+"""
+	buffertotalcount(::Camera) -> Int
+
+	Counts the number of image buffers that arrived since stream started.
+"""
+function buffertotalcount(cam::Camera)
+	Int(get(SpinIntegerNode(cam, "StreamTotalBufferCount", CameraTLStreamNodeMap())))
+end
 
 """
 	buffercount(::Camera) -> (Int, String)

--- a/src/camera/stream.jl
+++ b/src/camera/stream.jl
@@ -36,7 +36,9 @@ end
 	Counts the number of image buffers that arrived since stream started.
 """
 function totalbuffercount(cam::Camera)
-	Int(get(SpinIntegerNode(cam, "StreamTotalBufferCount", CameraTLStreamNodeMap())))
+	invalidate!(SpinIntegerNode(cam, "StreamTotalBufferCount", CameraTLStreamNodeMap()))
+    #poll!(cam, CameraTLStreamNodeMap())
+    return get(SpinIntegerNode(cam, "StreamTotalBufferCount", CameraTLStreamNodeMap()))
 end
 
 """


### PR DESCRIPTION
This function implementation seems right, but reading this seems to cause it to freeze to the value that's first read (on Ubuntu 18.04 and Windows 10, with 1.20.0.14/15 spinnaker)

i.e. if you read `buffertotalcount(cam)` before first `start!(cam)` then the result will be 0 and any subsequent calls to `buffertotalcount(cam)` will remain at 0

After a full OS restart, if you then read `buffertotalcount(cam)` after `start!(cam)` the value will be some number between 0 and inf, and will stay there.

@samuelpowell This is most likely to be a bug with Spinnaker, right?