### PR TITLE
Fix and update names for AutoExposureTime

### DIFF
--- a/src/Camera.jl
+++ b/src/Camera.jl
@@ -50,9 +50,8 @@ mutable struct Camera
     cam.names["AutoExposureTimeUpperLimit"] = "AutoExposureTimeUpperLimit"
     
     try
-      Spinnaker.get(Spinnaker.SpinIntegerNode(cam, "AutoExposureTimeLowerLimit"))
+      Spinnaker.get(Spinnaker.SpinFloatNode(cam, "AutoExposureTimeLowerLimit"))
     catch
-      @info "renameing exposure"
       cam.names["AutoExposureTimeLowerLimit"] = "AutoExposureExposureTimeLowerLimit"
       cam.names["AutoExposureTimeUpperLimit"] = "AutoExposureExposureTimeUpperLimit"
     end

--- a/src/Camera.jl
+++ b/src/Camera.jl
@@ -28,19 +28,36 @@ export serial, model, vendor, isrunning, start!, stop!, getimage, getimage!, sav
 """
 mutable struct Camera
   handle::spinCamera
+  names::Dict{String, String}
 
   function Camera(handle)
     @assert spinsys.handle != C_NULL
     @assert handle != C_NULL
     spinCameraDeInit(handle)
     spinCameraInit(handle)
-    cam = new(handle)
+    names = Dict{String, String}()
+    cam = new(handle, names)
     finalizer(_release!, cam)
+    
     # Activate chunk mode
     set!(SpinBooleanNode(cam, "ChunkModeActive"), true)
     _chunkselect(cam, ["FrameID", "FrameCounter"], "frame indentification")
     _chunkselect(cam, ["ExposureTime"], "exposure time")
     _chunkselect(cam, ["Timestamp"], "timestamps")
+
+    # Discover ambiguous names
+    cam.names["AutoExposureTimeLowerLimit"] = "AutoExposureTimeLowerLimit"
+    cam.names["AutoExposureTimeUpperLimit"] = "AutoExposureTimeUpperLimit"
+    
+    try
+      Spinnaker.get(Spinnaker.SpinIntegerNode(cam, "AutoExposureTimeLowerLimit"))
+    catch
+      @info "renameing exposure"
+      cam.names["AutoExposureTimeLowerLimit"] = "AutoExposureExposureTimeLowerLimit"
+      cam.names["AutoExposureTimeUpperLimit"] = "AutoExposureExposureTimeUpperLimit"
+    end
+
+
     return cam
   end
 end

--- a/src/camera/acquisition.jl
+++ b/src/camera/acquisition.jl
@@ -133,8 +133,8 @@ exposure_limits(cam::Camera) = range(SpinFloatNode(cam, "ExposureTime"))
   Write lower and upper limits of the Auto Exposure Time (us) value.
 """
 function autoexposure_limits!(cam::Camera, lims)
-  set!(SpinFloatNode(cam, "AutoExposureTimeLowerLimit"), lims[1])
-  set!(SpinFloatNode(cam, "AutoExposureTimeUpperLimit"), lims[2])
+  set!(SpinFloatNode(cam, cam.names["AutoExposureTimeLowerLimit"]), lims[1])
+  set!(SpinFloatNode(cam, cam.names["AutoExposureTimeUpperLimit"]), lims[2])
   autoexposure_limits(cam)
 end
 
@@ -143,7 +143,10 @@ end
 
   Lower and upper limits of the Auto Exposure Time (us) value.
 """
-autoexposure_limits(cam::Camera) = (get(SpinFloatNode(cam, "AutoExposureTimeLowerLimit")), get(SpinFloatNode(cam, "AutoExposureTimeUpperLimit")))
+function autoexposure_limits(cam::Camera)
+  (get(SpinFloatNode(cam, cam.names["AutoExposureTimeLowerLimit"])),
+   get(SpinFloatNode(cam, cam.names["AutoExposureTimeUpperLimit"])))
+end
 
 """
   framerate(::Camera) -> Float


### PR DESCRIPTION
Some cameras name this node `AutoExposureTimeLowerLimit`, other `AutoExposureExposureTimeLowerLimit`. Test at init, catch, and cache.