### PR TITLE
Enable _copyimage! to GPU

### DIFF
--- a/src/Camera.jl
+++ b/src/Camera.jl
@@ -341,7 +341,7 @@ end
   precision numbers in the range [0, 255]. `If normalize == true` the input data is interpreted as
   an associated fixed point format, and thus the array will be in the range [0,1].
 """
-function getimage!(cam::Camera, image::Array{T,2}; normalize=true, release=true, timeout=-1) where T
+function getimage!(cam::Camera, image::AbstractArray{T,2}; normalize=true, release=true, timeout=-1) where T
 
   himage_ref, width, height, id, timestamp, exposure = _pullim(cam, timeout=timeout)
   _copyimage!(himage_ref[], width, height, image, normalize)

--- a/src/CameraImage.jl
+++ b/src/CameraImage.jl
@@ -94,7 +94,7 @@ function _copyimage!(himage_ref::spinImage,
     data = unsafe_wrap(Array,  Ptr{Ti}(rawptr[]), (width, height));
     
     # Convert and copy data from buffer
-    image .= T.(data)
+    copyto!(image, T.(data))
     return image
   
   end


### PR DESCRIPTION
Replace broadcast assignment with direct copy to, should allow for no-op transfer to GPU for matching types.