### PR TITLE
Fixes for macOS

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,7 +15,9 @@ function find_spinnaker()
     libspinnaker = "libSpinnaker_C.so"
     libspinvideo = "libSpinVideo_C.so"
   else
-    @error "Spinnaker SDK only supported on Linux and Windows platforms"
+    path = "/usr/local/lib"
+    libspinnaker = "libSpinnaker_C.dylib"
+    libspinvideo = "libSpinVideo_C.dylib"
   end
 
   return path, libspinnaker, libspinvideo


### PR DESCRIPTION
I can confirm that Spinnaker now works with macOS. This uses libSpinnaker_C.dylib.1.26.0.31.