### PR TITLE
Add tests (local only, given need for camera) and enable use on MacOS (slight mod of #52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ deps/deps.jl
 deps/build.log
 examples/wrapper/output/*
 examples/*.png
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -2,9 +2,16 @@ name = "Spinnaker"
 uuid = "8e0d2ad3-56b8-53f3-8036-54b674872bef"
 version = "0.1.5"
 
-[compat]
-julia = "≥ 0.7.0"
-
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[compat]
+julia = "≥ 0.7.0"
+
+[extras]
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ImageCore", "Test"]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,8 +14,12 @@ function find_spinnaker()
     path = "/usr/lib"
     libspinnaker = "libSpinnaker_C.so"
     libspinvideo = "libSpinVideo_C.so"
+  elseif Sys.isapple()
+    path = "/usr/local/lib"
+    libspinnaker = "libSpinnaker_C.dylib"
+    libspinvideo = "libSpinVideo_C.dylib"
   else
-    @error "Spinnaker SDK only supported on Linux and Windows platforms"
+    @error "Spinnaker SDK only supported on Linux, Windows and MacOS platforms"
   end
 
   return path, libspinnaker, libspinvideo

--- a/src/camera/acquisition.jl
+++ b/src/camera/acquisition.jl
@@ -157,6 +157,12 @@ function framerate(cam::Camera)
   get(SpinFloatNode(cam, "AcquisitionFrameRate"))
 end
 
+"""
+  framerate!(::Camera)
+
+  Activate (continuous) automatic framerate control on specified camera.
+"""
+framerate!(cam::Camera) = set!(SpinEnumNode(cam, "AcquisitionFrameRateAuto"), "Continuous")
 
 """
   framerate!(::Camera, ::Number) -> Float
@@ -166,10 +172,10 @@ end
   is returned.
 """
 function framerate!(cam::Camera, fps)
+  set!(SpinEnumNode(cam, "AcquisitionFrameRateAuto"), "Off")
   set!(SpinBooleanNode(cam, cam.names["AcquisitionFrameRateEnabled"]), true)
   set!(SpinFloatNode(cam, "AcquisitionFrameRate"), fps)
 end
-
 
 """
   framerate_limits(::Camera) -> (Float, Float)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,37 @@
+using Spinnaker, Test, ImageCore
+
+@testset "Camera Interaction" begin
+    camlist = CameraList()
+    @test length(camlist) >= 1
+    cam = camlist[0]
+    @test typeof(cam) == Spinnaker.Camera
+
+    @testset "Set continuous mode" begin
+        triggermode!(cam, "Off")
+        @test triggermode(cam) == "Off"
+
+        acquisitionmode!(cam, "Continuous")
+        @test acquisitionmode(cam) == "Continuous"
+
+        framerate!(cam, 60)
+        @test framerate(cam) == 60
+    end
+
+    @testset "Set exposure" begin
+        exposure!(cam, 4000)
+        exp, mode = exposure(cam)
+        @test isapprox(exp, 4000, rtol=0.1)
+        @test mode == "Off"
+
+        exposure!(cam)
+        exp, mode = exposure(cam)
+        @test mode == "Continuous"
+    end
+
+    @testset "Read image" begin
+        start!(cam)
+        img = getimage(cam, Gray{N0f8}, normalize=true)
+        @test all(size(img) .> 0)
+        stop!(cam)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,37 +1,57 @@
-using Spinnaker, Test, ImageCore
+using Test, ImageCore
+function is_ci()
+    get(ENV, "TRAVIS", "") == "true" ||
+    get(ENV, "APPVEYOR", "") in ("true", "True") ||
+    get(ENV, "CI", "") in ("true", "True")
+end
 
-@testset "Camera Interaction" begin
+if is_ci()
+    @info "CI testing is disabled due to the need for a Spinnaker-compatible camera during tests."
+else
+    using Spinnaker
+
     camlist = CameraList()
-    @test length(camlist) >= 1
-    cam = camlist[0]
-    @test typeof(cam) == Spinnaker.Camera
+    if length(camlist) < 1
+        error("""Spinnaker could not find a compatible camera.
+        Tests require that a Spinnaker-compatible camera is connected and discoverable.
+        If such a camera is connected, check that it is discoverable in SpinView""")
+    else
+        @testset "Camera Interaction" begin
+            cam = camlist[0]
+            @test typeof(cam) == Spinnaker.Camera
 
-    @testset "Set continuous mode" begin
-        triggermode!(cam, "Off")
-        @test triggermode(cam) == "Off"
+            @testset "Set continuous mode" begin
+                triggermode!(cam, "Off")
+                @test triggermode(cam) == "Off"
 
-        acquisitionmode!(cam, "Continuous")
-        @test acquisitionmode(cam) == "Continuous"
+                acquisitionmode!(cam, "Continuous")
+                @test acquisitionmode(cam) == "Continuous"
 
-        framerate!(cam, 60)
-        @test framerate(cam) == 60
-    end
+                framerate!(cam, 60.0)
+                @test isapprox(framerate(cam), 60.0)
+            end
 
-    @testset "Set exposure" begin
-        exposure!(cam, 4000)
-        exp, mode = exposure(cam)
-        @test isapprox(exp, 4000, rtol=0.1)
-        @test mode == "Off"
+            @testset "Set exposure" begin
+                exposure!(cam, 4000)
+                exp, mode = exposure(cam)
+                @test isapprox(exp, 4000, rtol=0.1)
+                @test mode == "Off"
 
-        exposure!(cam)
-        exp, mode = exposure(cam)
-        @test mode == "Continuous"
-    end
+                exposure!(cam)
+                exp, mode = exposure(cam)
+                @test mode == "Continuous"
+            end
 
-    @testset "Read image" begin
-        start!(cam)
-        img = getimage(cam, Gray{N0f8}, normalize=true)
-        @test all(size(img) .> 0)
-        stop!(cam)
+            @testset "Read image" begin
+                @testset "Mono8" begin
+                    pixelformat!(cam, "Mono8")
+                    @assert pixelformat(cam) == "Mono8"
+                    start!(cam)
+                    img = getimage(cam, Gray{N0f8}, normalize=true)
+                    @test all(size(img) .> 0)
+                    stop!(cam)
+                end
+            end
+        end
     end
 end


### PR DESCRIPTION
I thought I'd add some basic tests, given I often just want to try this on different cameras.

Currently these tests pass on my mono grasshopper3, but fail on its RGB equivalent. Not sure why yet.

Also, includes (a slightly modified) #52, so works with the new MacOS spinnaker SDK