### PR TITLE
Optional suppression of clamp warning during set!

### DIFF
--- a/src/Nodes.jl
+++ b/src/Nodes.jl
@@ -80,13 +80,15 @@ function range(node::SpinIntegerNode)
   return (hMin[], hMax[])
 end
 
-function set!(node::SpinIntegerNode, value::Number)
+function set!(node::SpinIntegerNode, value::Number; clampwarn::Bool = true)
   if !writable(node.hNode)
     throw(ErrorException("Node $(node.name) is not writable"))
   end
   noderange = range(node)
-  value < noderange[1] && @warn "Requested value ($value) is smaller than minimum ($(noderange[1])), value will be clamped."
-  value > noderange[2] && @warn "Requested value ($value) is greater than maximum ($(noderange[2])), value will be clamped."
+  if clampwarn
+    value < noderange[1] && @warn "Requested value ($value) is smaller than minimum ($(noderange[1])), value will be clamped."
+    value > noderange[2] && @warn "Requested value ($value) is greater than maximum ($(noderange[2])), value will be clamped."
+  end
   spinIntegerSetValue(node.hNode[], Int64(clamp(value, noderange[1], noderange[2])))
   get(node)  
 end


### PR DESCRIPTION
Non-critical.
It can be useful to set limits to values outside of the allowable range, to return the range that is allowed.

i.e.
```
> autoExposureLimits = autoexposure_limits!(cam, (0, 1e9))
┌ Warning: Requested value (1.0e9) is greater than maximum (42312.6220703125), value will be clamped.
└ @ Spinnaker ~/.julia/packages/Spinnaker/f22YA/src/Nodes.jl:129
```

This PR allows suppression of warning for that case:
```
> autoExposureLimits = autoexposure_limits!(cam, (0, 1e9), clampwarn = false)
```