### PR TITLE
Add control of autoexposure and lighting metering

### DIFF
--- a/src/Camera.jl
+++ b/src/Camera.jl
@@ -8,6 +8,7 @@ export serial, model, vendor, isrunning, start!, stop!, getimage, getimage!, sav
        trigger!,
        exposure, exposure!, exposure_limits,
        autoexposure_limits, autoexposure_limits!,
+       autoexposure_metering_mode!, autoexposure_lighting_mode!,
        framerate, framerate!, framerate_limits,
        gain, gain!, gain_limits,
        adcbits, adcbits!,
@@ -38,7 +39,7 @@ mutable struct Camera
     names = Dict{String, String}()
     cam = new(handle, names)
     finalizer(_release!, cam)
-    
+
     # Activate chunk mode
     set!(SpinBooleanNode(cam, "ChunkModeActive"), true)
     _chunkselect(cam, ["FrameID", "FrameCounter"], "frame indentification")
@@ -49,7 +50,7 @@ mutable struct Camera
     cam.names["AutoExposureTimeLowerLimit"] = "AutoExposureTimeLowerLimit"
     cam.names["AutoExposureTimeUpperLimit"] = "AutoExposureTimeUpperLimit"
     cam.names["AcquisitionFrameRateEnabled"] = "AcquisitionFrameRateEnabled"
-        
+
     try
       Spinnaker.get(Spinnaker.SpinFloatNode(cam, "AutoExposureTimeLowerLimit"))
     catch
@@ -75,7 +76,7 @@ function _chunkselect(cam::Camera, chunknames::Vector{String}, desc::String)
   fail = true
   i = 1
   while fail == true
-    try 
+    try
       fail = false
       set!(SpinEnumNode(cam, "ChunkSelector"), chunknames[i])
       set!(SpinBooleanNode(cam, "ChunkEnable"), true)
@@ -248,7 +249,7 @@ end
   format, and thus the array will be in the range [0,1].
 
   To return images compatible with Images.jl, one can request a Gray value, e.g.,
-  `getimage!(cam, Gray{N0f8}, normalize=true)`. 
+  `getimage!(cam, Gray{N0f8}, normalize=true)`.
 
   Function also returns image ID and timestamp metadata.
 """

--- a/src/camera/acquisition.jl
+++ b/src/camera/acquisition.jl
@@ -149,6 +149,52 @@ function autoexposure_limits(cam::Camera)
 end
 
 """
+  autoexposure_lighting_mode!(::Camera, mode::String)
+
+  Change autoexposure lighting mode.
+  Options:
+  - "AutoDetect":
+  - "Backlight": Used when a strong light is coming from the back of the object.
+  - "Frontlight": Used when a strong light is shining in the front of the object
+                  while the background is dark.
+  - "Normal": Used when the object is not under backlight or frontlight conditions
+"""
+function autoexposure_lighting_mode!(cam::Camera, mode::String)
+  if in(mode, ["AutoDetect", "Backlight", "Frontlight", "Normal"])
+    set!(SpinEnumNode(cam, "AutoExposureLightingMode"), mode)
+  else
+    @error """Lighting mode "$(mode)" not recognized"""
+  end
+end
+
+"""
+  autoexposure_metering_mode!(::Camera)
+
+  Change to "Normal" lighting mode and set the autoexposure metering mode.
+  Options:
+  - "Average": Measures the light from the entire scene uniformly to determine
+                the final exposure value. Every portion of the exposed area has
+                the same contribution.
+  - "Spot": Measures a small area (about 3%) in the center of the scene while
+                the rest of the scene is ignored. This mode is used when the
+                scene has a high contrast and the object of interest is relatively
+                small.
+  - "Partial": Measures the light from a larger area (about 11%) in the center
+                of the scene. This mode is used when very dark or bright regions
+                appear at the edge of the frame.
+  - "CenterWeighted"
+  - "HistgramPeak"
+"""
+function autoexposure_metering_mode!(cam::Camera, mode::String)
+  if in(mode, ["Average","Spot","Partial","CenterWeighted","HistgramPeak"])
+    autoexposure_lighting_mode!(cam, "Normal")
+    set!(SpinEnumNode(cam, "AutoExposureMeteringMode"), mode)
+  else
+    @error """Metering mode "$(mode)" not recognized"""
+  end
+end
+
+"""
   framerate(::Camera) -> Float
 
   Camera frame rate.


### PR DESCRIPTION
This isn't working for me, but it may be a camera support issue, given neither `AutoExposureLightingMode` nor `AutoExposureMeteringMode` are present in spinview for my camera.

```
  autoexposure_lighting_mode!(::Camera, mode::String)

  Change autoexposure lighting mode.
  Options:
  - "AutoDetect": Automatically detect
  - "Backlight": Used when a strong light is coming from the back of the object.
  - "Frontlight": Used when a strong light is shining in the front of the object
                  while the background is dark.
  - "Normal": Used when the object is not under backlight or frontlight conditions
```
```
  autoexposure_metering_mode!(::Camera)

  Change to "Normal" lighting mode and set the autoexposure metering mode.
  Options:
  - "Average": Measures the light from the entire scene uniformly to determine
                the final exposure value. Every portion of the exposed area has
                the same contribution.
  - "Spot": Measures a small area (about 3%) in the center of the scene while
                the rest of the scene is ignored. This mode is used when the
                scene has a high contrast and the object of interest is relatively
                small.
  - "Partial": Measures the light from a larger area (about 11%) in the center
                of the scene. This mode is used when very dark or bright regions
                appear at the edge of the frame.
  - "CenterWeighted": (No SDK docs)
  - "HistgramPeak": (No SDK docs)
```