### PR TITLE
Missing clampwarn changes

### DIFF
--- a/src/Nodes.jl
+++ b/src/Nodes.jl
@@ -122,13 +122,15 @@ function range(node::SpinFloatNode)
   return (hMin[], hMax[])
 end
 
-function set!(node::SpinFloatNode, value::Number)
+function set!(node::SpinFloatNode, value::Number; clampwarn::Bool = true)
   if !writable(node.hNode)
     throw(ErrorException("Node $(node.name) is not writable"))
   end
   noderange = range(node)
-  value < noderange[1] && @warn "Requested value ($value) is smaller than minimum ($(noderange[1])), value will be clamped."
-  value > noderange[2] && @warn "Requested value ($value) is greater than maximum ($(noderange[2])), value will be clamped."
+  if clampwarn
+    value < noderange[1] && @warn "Requested value ($value) is smaller than minimum ($(noderange[1])), value will be clamped."
+    value > noderange[2] && @warn "Requested value ($value) is greater than maximum ($(noderange[2])), value will be clamped."
+  end
   spinFloatSetValue(node.hNode[], Float64(clamp(value, noderange[1], noderange[2])))
   get(node)  
 end

--- a/src/camera/acquisition.jl
+++ b/src/camera/acquisition.jl
@@ -128,13 +128,15 @@ end
 exposure_limits(cam::Camera) = range(SpinFloatNode(cam, "ExposureTime"))
 
 """
-  autoexposure_limits!(::Camera, (lower, upper)) -> (Float, Float)
+  autoexposure_limits!(::Camera, (lower, upper); clampwarn=true) -> (Float, Float)
 
   Write lower and upper limits of the Auto Exposure Time (us) value.
+  Values exceeding range are clamped to the allowable extrema and returned, and
+  a warning is given, which can be disabled with `clampwarn=false`.
 """
-function autoexposure_limits!(cam::Camera, lims)
-  set!(SpinFloatNode(cam, cam.names["AutoExposureTimeLowerLimit"]), lims[1])
-  set!(SpinFloatNode(cam, cam.names["AutoExposureTimeUpperLimit"]), lims[2])
+function autoexposure_limits!(cam::Camera, lims; clampwarn=true)
+  set!(SpinFloatNode(cam, cam.names["AutoExposureTimeLowerLimit"]), lims[1], clampwarn=clampwarn)
+  set!(SpinFloatNode(cam, cam.names["AutoExposureTimeUpperLimit"]), lims[2], clampwarn=clampwarn)
   autoexposure_limits(cam)
 end
 


### PR DESCRIPTION
Apologies @samuelpowell.. I was missing a commit on #56 and somehow failed to notice it given my local branch was working.

This completes the clampwarn functionality for `autoexposure_limits!`