### PR TITLE
Update FIxedPointNumbers compat, add basic CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ['1', 'nightly']
+        julia-arch: [x64]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          - os: macOS-latest
+            julia-arch: x86
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/julia-runtest@latest
+        env:
+          JULIA_NUM_THREADS: 2
+      - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
 julia = "0.7, 1"
-FixedPointNumbers = "^0.6.0"
+FixedPointNumbers = "0.6, 0.7, 0.8"
 
 [extras]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,11 +5,11 @@ function is_ci()
     get(ENV, "CI", "") in ("true", "True")
 end
 
+using Spinnaker
+
 if is_ci()
     @info "CI testing is disabled due to the need for a Spinnaker-compatible camera during tests."
 else
-    using Spinnaker
-
     camlist = CameraList()
     if length(camlist) < 1
         error("""Spinnaker could not find a compatible camera.


### PR DESCRIPTION
@samuelpowell I'm adding basic CI testing here, given that we at least should check that the package installs and loads, even if the tests are bypassed on CI due to the lack of spinnaker sdk and camera on the github runners