### PR TITLE
Add SpinError exception type to propagate error value

### DIFF
--- a/src/Spinnaker.jl
+++ b/src/Spinnaker.jl
@@ -6,9 +6,9 @@ module Spinnaker
 using FixedPointNumbers
 
 using Libdl
-import Base: unsafe_convert, show, length, getindex, size, convert, range
+import Base: unsafe_convert, show, length, getindex, size, convert, range, showerror
 
-export System, Camera, CameraList
+export System, Camera, CameraList, SpinError
 
 const libSpinnaker_C = Ref{String}("")
 const libSpinVideo_C = Ref{String}("")
@@ -21,9 +21,14 @@ using .CEnum
 
 include("wrapper/spin_common.jl")
 
+struct SpinError <: Exception
+  val::spinError
+end
+showerror(io::IO, ex::SpinError) = print(io, "Spinnaker SDK error: ", ex.val)
+
 function checkerror(err::spinError)
   if err != spinError(0)
-    throw(ErrorException("Spinnaker SDK error: $err"))
+    throw(SpinError(err))
   end
   return nothing
 end


### PR DESCRIPTION
Adds a `SpinError` exception type with a `val` field, such that the Spinnaker SDK `spinError` enum value can be saved and compared. Currently the `ErrorException` that is returned has to be string compared via the `msg` field, which is suboptimal.

Should be a breaking change release.

Errors will still show the same way.

```
julia> reset!(cam); start!(cam)
ERROR: Spinnaker SDK error: SPINNAKER_ERR_NOT_INITIALIZED(-1002)
Stacktrace:
 [1] checkerror
   @ ~/.julia/dev/Spinnaker/src/Spinnaker.jl:31 [inlined]
 [2] spinCameraBeginAcquisition
   @ ~/.julia/dev/Spinnaker/src/wrapper/spin_api.jl:321 [inlined]
 [3] start!(cam::Camera)
   @ Spinnaker ~/.julia/dev/Spinnaker/src/camera/acquisition.jl:23
 [4] top-level scope
   @ REPL[18]:1
```

But they can be caught and value compared
```julia
julia> try
         reset!(cam)
         start!(cam)
       catch ex
         if ex isa SpinError
            ex.val == Spinnaker.SPINNAKER_ERR_NOT_INITIALIZED && println("gotcha")
         end
       end
gotcha
```