### PR TITLE
Add auto-gain limits and auto-exposure priority control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ deps/build.log
 examples/wrapper/output/*
 examples/*.png
 Manifest.toml
+.vscode
+

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "Spinnaker"
 uuid = "8e0d2ad3-56b8-53f3-8036-54b674872bef"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
-julia = "0.7, 1"
 FixedPointNumbers = "0.6, 0.7, 0.8"
+julia = "0.7, 1"
 
 [extras]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"

--- a/src/camera/acquisition.jl
+++ b/src/camera/acquisition.jl
@@ -151,6 +151,27 @@ function autoexposure_limits(cam::Camera)
 end
 
 """
+  autoexposure_control_priority!(cam::Camera, priority)
+
+  Select whether to adjust gain or exposure first. `priority` can be one of `"Gain"`, `"ExposureTime"`.
+  See Spinnaker SDK docs section 12.6.2.6 `enum AutoExposureControlPriorityEnums` for more information.
+"""
+function autoexposure_control_priority!(cam::Camera, priority)
+  set!(SpinEnumNode(cam, "AutoExposureControlPriority"), priority)
+  autoexposure_control_priority(cam)
+end
+
+"""
+  autoexposure_control_priority(cam::Camera)
+
+  Get the auto-exposure control priority. One of `"Gain"`, `"Exposure"`.
+  See Spinnaker SDK docs section 12.6.2.6 `enum AutoExposureControlPriorityEnums` for more information.
+"""
+function autoexposure_control_priority(cam::Camera)
+  get(SpinEnumNode(cam, "AutoExposureControlPriority"))
+end
+
+"""
   framerate(::Camera) -> Float
 
   Camera frame rate.

--- a/src/camera/acquisition.jl
+++ b/src/camera/acquisition.jl
@@ -164,7 +164,7 @@ end
 """
   autoexposure_control_priority(cam::Camera)
 
-  Get the auto-exposure control priority. One of `"Gain"`, `"Exposure"`.
+  Get the auto-exposure control priority. One of `"Gain"`, `"ExposureTime"`.
   See Spinnaker SDK docs section 12.6.2.6 `enum AutoExposureControlPriorityEnums` for more information.
 """
 function autoexposure_control_priority(cam::Camera)

--- a/src/camera/analog.jl
+++ b/src/camera/analog.jl
@@ -34,6 +34,28 @@ end
 """
 gain_limits(cam::Camera) = range(SpinFloatNode(cam,"Gain"))
 
+"""
+  autogain_limits!(::Camera, (lower, upper); clampwarn=true) -> (Float, Float)
+
+  Write lower and upper limits of the Auto Gain Time (us) value.
+  Values exceeding range are clamped to the allowable extrema and returned, and
+  a warning is given, which can be disabled with `clampwarn=false`.
+"""
+function autogain_limits!(cam::Camera, lims; clampwarn=true)
+  set!(SpinFloatNode(cam, "AutoExposureGainLowerLimit"), lims[1], clampwarn=clampwarn)
+  set!(SpinFloatNode(cam, "AutoExposureGainUpperLimit"), lims[2], clampwarn=clampwarn)
+  autogain_limits(cam)
+end
+
+"""
+  autogain_limits(::Camera) -> (Float, Float)
+
+  Lower and upper limits of the Auto Gain Time (us) value.
+"""
+function autogain_limits(cam::Camera)
+  (get(SpinFloatNode(cam, "AutoExposureGainLowerLimit")),
+   get(SpinFloatNode(cam, "AutoExposureGainUpperLimit")))
+end
 
 """
   gammaenable(::Camera) -> Bool


### PR DESCRIPTION
This PR exposes the auto-gain limits in the Spinnaker SDK. The nodes are called `AutoExposureGain...` for some reason,
but the auto-gain can be enabled separately from auto-exposure, so I have just called the functions `autogain` instead
of `autoexposure_gain` or similar.

I tested this with a real camera. Changing the auto-gain limits in code produces the same behavior as when changing
them in SpinView.
