### PR TITLE
Corrected path and library for latest SDK as of 3.0.0.118

### DIFF
--- a/src/Spinnaker.jl
+++ b/src/Spinnaker.jl
@@ -66,9 +66,9 @@ end
 # Create a System object at runtime
 function init()
   @static if Sys.iswindows()
-    paths = [joinpath(ENV["ProgramFiles"], "Point Grey Research", "Spinnaker", "bin", "vs2015")]
+    paths = [joinpath(ENV["ProgramFiles"], "FLIR Systems", "Spinnaker", "bin64", "vs2015")]
     libspinnaker = "SpinnakerC_v140.dll"
-    libspinvideo = ""
+    libspinvideo = "SpinVideoC_v140.dll"
   elseif Sys.islinux()
     paths = ["/usr/lib" "/opt/spinnaker/lib"]
     libspinnaker = "libSpinnaker_C.so"

--- a/src/Spinnaker.jl
+++ b/src/Spinnaker.jl
@@ -66,7 +66,11 @@ end
 # Create a System object at runtime
 function init()
   @static if Sys.iswindows()
-    paths = [joinpath(ENV["ProgramFiles"], "FLIR Systems", "Spinnaker", "bin64", "vs2015")]
+    if isdir(joinpath(ENV["ProgramFiles"], "Point Grey Research", "Spinnaker", "bin", "vs2015"))
+      paths = [joinpath(ENV["ProgramFiles"], "Point Grey Research", "Spinnaker", "bin", "vs2015")]
+    elseif isdir(joinpath(ENV["ProgramFiles"], "FLIR Systems", "Spinnaker", "bin64", "vs2015"))
+      paths = [joinpath(ENV["ProgramFiles"], "FLIR Systems", "Spinnaker", "bin64", "vs2015")]
+    end
     libspinnaker = "SpinnakerC_v140.dll"
     libspinvideo = "SpinVideoC_v140.dll"
   elseif Sys.islinux()

--- a/src/Spinnaker.jl
+++ b/src/Spinnaker.jl
@@ -70,6 +70,8 @@ function init()
       paths = [joinpath(ENV["ProgramFiles"], "Point Grey Research", "Spinnaker", "bin", "vs2015")]
     elseif isdir(joinpath(ENV["ProgramFiles"], "FLIR Systems", "Spinnaker", "bin64", "vs2015"))
       paths = [joinpath(ENV["ProgramFiles"], "FLIR Systems", "Spinnaker", "bin64", "vs2015")]
+    elseif isdir(joinpath(ENV["ProgramFiles"], "Teledyne", "Spinnaker", "bin64", "vs2015"))
+      paths = [joinpath(ENV["ProgramFiles"], "Teledyne", "Spinnaker", "bin64", "vs2015")]
     end
     libspinnaker = "SpinnakerC_v140.dll"
     libspinvideo = "SpinVideoC_v140.dll"


### PR DESCRIPTION
As I hit bug #64, and I did not see a PR already submitted for this, here is one. It corrects the path for the latest version of the Spinnaker SDK (3.0.0.118 at the time of writing) and adds in the DLL name for the video DLL. It is tested minimally and working for me on Windows 10 with Julia 1.8.5.