### PR TITLE
move init to first usage of CameraList

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Spinnaker"
 uuid = "8e0d2ad3-56b8-53f3-8036-54b674872bef"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/README.md
+++ b/README.md
@@ -347,6 +347,4 @@ Check that you have the environment variable `FLIR_GENTL64_CTI` set to the path 
 
 Given Spinnaker is a non-JLL managed dependency, it is sometimes helpful to delay the lib init
 so that julia has preference over which libraries are loaded.
-The simple way to do this is to load Spinnaker after other packages. However, if Spinnaker is in a sysimage
-and thus has its `__init__()` called on julia load, you can delay the lib init by setting
-`ENV["JULIA_SPINNAKER_MANUAL_INIT"]="true"` and loading julia packages before calling `Spinnaker.init()` manually.
+From v1.1.1 Spinnaker.jl initializes the Spinnaker SDK during first usage of CameraList.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ Check that you have the environment variable `FLIR_GENTL64_CTI` set to the path 
 
 ### Loading Spinnaker causes binary dependency (i.e. JLL) errors in other packages
 
-Given Spinnaker is a non-JLL managed dependency, it is sometimes helpful to delay the lib init
-so that julia has preference over which libraries are loaded.
-From v1.1.1 Spinnaker.jl initializes the Spinnaker SDK during first usage of CameraList.
+From v1.1.1 Spinnaker.jl initializes the Spinnaker SDK during first usage of `CameraList()`.
+If you need to call any of the SDK's native functions before using `CameraList()`, then call `Spinnaker.init()` manually.
+
+Prior to v1.1.1, Spinnaker.jl initializes the SDK inside its `__init__()` function, called on Julia load.
+You can delay this by setting `ENV["JULIA_SPINNAKER_MANUAL_INIT"]="true"` and loading Julia packages before calling `Spinnaker.init()` manually.

--- a/src/CameraList.jl
+++ b/src/CameraList.jl
@@ -15,6 +15,7 @@ mutable struct CameraList
   handle::spinCameraList
 
   function CameraList()
+    system_initialized || init()
     hcamlist_ref = Ref(spinCameraList(C_NULL))
     spinCameraListCreateEmpty(hcamlist_ref)
     @assert hcamlist_ref[] != C_NULL

--- a/src/Spinnaker.jl
+++ b/src/Spinnaker.jl
@@ -54,14 +54,7 @@ include("Nodes.jl")
 get_bool_env(name::String; default::String="false") =
     lowercase(Base.get(ENV, name, default)) in ("t", "true", "y", "yes", "1")
 
-function __init__()
-  # Given Spinnaker is a non-JLL managed dependency, it is sometimes helpful to delay the lib init
-  # so that julia has preference over which libraries are loaded.
-  # i.e. set this env var and load julia packages before calling Spinnaker.init()
-  if !get_bool_env("JULIA_SPINNAKER_MANUAL_INIT", default = "false")
-    init()
-  end
-end
+system_initialized = false
 
 # Create a System object at runtime
 function init()
@@ -78,8 +71,7 @@ function init()
     libspinnaker = "libSpinnaker_C.dylib"
     libspinvideo = "libSpinVideo_C.dylib"
   else
-    @error "Spinnaker SDK only supported on Linux, Windows and MacOS platforms"
-    return
+    error("Spinnaker SDK is only supported on Linux, Windows and MacOS platforms")
   end
   libSpinnaker_C_path = ""
   libSpinVideo_C_path = ""
@@ -93,20 +85,18 @@ function init()
   end
 
   if libSpinnaker_C[] == "" || libSpinVideo_C[] == ""
-    @error "Spinnaker SDK cannot be found. This package can be loaded, but will not be functional."
-    return
+    error("Spinnaker SDK cannot be found.")
   end
   try
     libSpinnaker_C_handle = dlopen(libSpinnaker_C[])
     !Sys.iswindows() && (libSpinVideo_C_handle = dlopen(libSpinVideo_C[]))
-  catch ex
-    bt = catch_backtrace()
+  catch
     @error "Spinnaker SDK cannot be dlopen-ed"
-    showerror(stderr, ex, bt)
+    rethrow()
   end
   try
     global spinsys = System()
-  catch ex
+  catch
     bt = catch_backtrace()
     @error "Spinnaker SDK loaded but Spinnaker.jl failed to initialize"
     if !haskey(ENV, "FLIR_GENTL64_CTI")
@@ -114,8 +104,9 @@ function init()
     elseif !endswith(ENV["FLIR_GENTL64_CTI"], "FLIR_GenTL.cti")
       @warn "The environment has the variable `FLIR_GENTL64_CTI`, but it does not point to `FLIR_GenTL.cti`, which may be the cause of this error. Check that it is set to the path to `FLIR_GenTL.cti` (e.g. `/opt/spinnaker/lib/flir-gentl/FLIR_GenTL.cti`)."
     end
-    showerror(stderr, ex, bt)
+    rethrow()
   end
+  system_initialized = true
 end
 
 end # module

--- a/src/Spinnaker.jl
+++ b/src/Spinnaker.jl
@@ -58,6 +58,11 @@ system_initialized = false
 
 # Create a System object at runtime
 function init()
+  if haskey(ENV, "JULIA_SPINNAKER_MANUAL_INIT")
+    @warn """
+      The environment variable `JULIA_SPINNAKER_MANUAL_INIT` is deprecated.
+      Spinnaker is initialized during first CameraList usage""" maxlog=1
+  end
   @static if Sys.iswindows()
     paths = [joinpath(ENV["ProgramFiles"], "Point Grey Research", "Spinnaker", "bin", "vs2015")]
     libspinnaker = "SpinnakerC_v140.dll"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,9 @@ else
                 acquisitionmode!(cam, "Continuous")
                 @test acquisitionmode(cam) == "Continuous"
 
-                framerate!(cam, 60.0)
-                @test isapprox(framerate(cam), 60.0)
+                max_framerate = framerate_limits(cam)[end]
+                framerate!(cam, max_framerate)
+                @test isapprox(framerate(cam), max_framerate)
             end
 
             @testset "Set exposure" begin


### PR DESCRIPTION
It's become bad practice to do anything other than load the julia package during package load. `__init__()` usage is recommended against.

Also, if Spinnaker was baked into a sysimage the previous `__init__()` warning logs were showing up during every subsequent precompilation job.

This should also help package load times.

I propose this is done in a patch bump as there shouldn't be any functional difference.


AFAICT `CameraList()` is a mandatory entry point for the package.